### PR TITLE
each_with_index over each for unique aws disk names

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source 'http://berks-api.optoro.io'
 
 metadata
+
+cookbook 'runit', '= 1.6.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'devops@optoro.com'
 license 'MIT'
 description 'Installs and configures Kafka'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.0'
+version '0.1.1'
 supports 'ubuntu', '= 14.04'
 
 depends 'apt'

--- a/recipes/zfs_on_ebs.rb
+++ b/recipes/zfs_on_ebs.rb
@@ -5,7 +5,7 @@
 include_recipe 'optoro_zfs'
 
 if node['ec2']
-  node['optoro_kafka']['disks'].each do |disk, index|
+  node['optoro_kafka']['disks'].each_with_index do |disk, index|
     aws_ebs_volume "kafka-#{index}" do
       size node['optoro_kafka']['disk_size']
       device disk


### PR DESCRIPTION
fixes an issue I am seeing with AWS only creating one disk instead of the expected 4
